### PR TITLE
BF/ENH: by default log_online=False and thuse use .communicate for Popen...

### DIFF
--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -66,7 +66,49 @@ class Runner(object):
         else:
             raise ValueError("Argument 'command' is neither a string nor a callable.")
 
-    def run(self, cmd, log_stdout=True, log_stderr=True):
+
+    def _get_output_online(self, proc, log_stderr, log_stdout, return_output=False):
+        stdout, stderr = [], []
+        while proc.poll() is None:
+            if log_stdout:
+                line = proc.stdout.readline()
+                if line != '':
+                    if return_output:
+                        stdout += line
+                    self.log("stdout| " + line.rstrip('\n'))
+                    # TODO: what level to log at? was: level=5
+                    # Changes on that should be properly adapted in
+                    # test.cmd.test_runner_log_stdout()
+            else:
+                pass
+
+            if log_stderr:
+                line = proc.stderr.readline()
+                if line != '':
+                    if return_output:
+                        stderr += line
+                    self.log("stderr| " + line.rstrip('\n'),
+                             level=logging.ERROR)
+                    # TODO: what's the proper log level here?
+                    # Changes on that should be properly adapted in
+                    # test.cmd.test_runner_log_stderr()
+            else:
+                pass
+
+        return stdout, stderr
+
+    def _get_output_communicate(self, proc, log_stderr, log_stdout, return_output=False):
+        """Delegate collection of output to proc.communicate.  It always collects
+        output, thus
+        """
+        out = proc.communicate()
+        for o, n in zip(out, ('stdout', 'stderr')):
+            if o:
+                self.log("%s| " % n + o.rstrip('\n'))
+        return out
+
+    def run(self, cmd, log_stdout=True, log_stderr=True,
+            log_online=False, return_output=False):
         """Runs the command `cmd` using shell.
 
         In case of dry-mode `cmd` is just added to `commands` and it is executed otherwise.
@@ -78,11 +120,19 @@ class Runner(object):
         cmd : str
           String defining the command call.
 
-        log_stdout: bool
+        log_stdout: bool, optional
             If True, stdout is logged. Goes to sys.stdout otherwise.
 
-        log_stderr: bool
+        log_stderr: bool, optional
             If True, stderr is logged. Goes to sys.stderr otherwise.
+
+        log_online: bool, optional
+            Either to log as output comes in.  Setting to True is preferable for
+            running user-invoked actions to provide timely output
+
+        return_output: bool, optional
+            If True, return a tuple of two strings (stdout, stderr) in addition
+            to the exit code
 
         Returns
         -------
@@ -92,6 +142,8 @@ class Runner(object):
         ------
         RunTimeError
            if command's exitcode wasn't 0 or None
+        (stdout, stderr)
+           if return_output=True
         """
 
         outputstream = subprocess.PIPE if log_stdout else sys.stdout
@@ -104,26 +156,13 @@ class Runner(object):
             proc = subprocess.Popen(cmd, stdout=outputstream, stderr=errstream, shell=True)
             # shell=True allows for piping, multiple commands, etc., but that implies to not use shlex.split()
             # and is considered to be a security hazard. So be careful with input.
-            # Alternatively we would have to parse `cmd` and create multiple subprocesses.
+            # Alternatively we would have to parse `cmd` and create multiple
+            # subprocesses.
 
-            while proc.poll() is None:
-                if log_stdout:
-                    line = proc.stdout.readline()
-                    if line != '':
-                        self.log("stdout| " + line.rstrip('\n'))
-                        # TODO: what level to log at? was: level=5
-                        # Changes on that should be properly adapted in test.cmd.test_runner_log_stdout()
-                else:
-                    pass
-
-                if log_stderr:
-                    line = proc.stderr.readline()
-                    if line != '':
-                        self.log("stderr| " + line.rstrip('\n'), level=logging.ERROR)
-                        # TODO: what's the proper log level here?
-                        # Changes on that should be properly adapted in test.cmd.test_runner_log_stderr()
-                else:
-                    pass
+            if log_online:
+                out = self._get_output_online(proc, log_stderr, log_stdout)
+            else:
+                out = self._get_output_communicate(proc, log_stderr, log_stdout)
 
             status = proc.poll()
 
@@ -138,7 +177,12 @@ class Runner(object):
 
         else:
             self.commands.append(cmd)
-        return None
+            out = ("DRY", "DRY")
+
+        if return_output:
+            return None, out
+        else:
+            return None
 
     def call(self, f, *args, **kwargs):
         """Helper to unify collection of logging all "dry" actions.

--- a/datalad/cmd.py
+++ b/datalad/cmd.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import logging
 import os
+import shutil
 
 lgr = logging.getLogger('datalad.cmd')
 
@@ -226,4 +227,11 @@ def link_file_load(src, dst, dry_run=False):
         # TODO: how would it interact with git/git-annex
         os.unlink(dst)
     lgr.debug("Hardlinking %(src)s under %(dst)s" % locals())
-    os.link(os.path.realpath(src), dst)
+    src_realpath = os.path.realpath(src)
+
+    try:
+        os.link(src_realpath, dst)
+    except  AttributeError, e:
+        lgr.warn("Linking of %s failed (%s), copying file" % (src, e))
+        shutil.copyfile(src_realpath, dst)
+        shutil.copystat(src_realpath, dst)

--- a/datalad/tests/test_cmd.py
+++ b/datalad/tests/test_cmd.py
@@ -118,7 +118,7 @@ def test_runner_log_stdout():
 
 
 @ignore_nose_capturing_stdout
-def test_runner_heavy_output():
+def check_runner_heavy_output(log_online):
     # TODO: again, no automatic detection of this resulting in being stucked yet.
 
     runner = Runner()
@@ -129,3 +129,15 @@ def test_runner_heavy_output():
     #do it again with capturing:
     ret = runner.run(cmd, log_stderr=True, log_stdout=True)
     assert_equal(0, ret, "Run of: %s resulted in exitcode %s" % (cmd, ret))
+
+    # and now original problematic command with a massive single line
+    if not log_online:
+        # We know it would get stuck in online mode
+        cmd = '%s -c "import sys; x=str(list(range(1000))); [(sys.stdout.write(x), sys.stderr.write(x)) for i in xrange(100)];"' % sys.executable
+        ret = runner.run(cmd, log_stderr=True, log_stdout=True)
+        assert_equal(0, ret, "Run of: %s resulted in exitcode %s" % (cmd, ret))
+
+def test_runner_heavy_output():
+    # TODO: RF sweep_args from PyMVPA to be used here
+    for log_online in [True, False]:
+        yield check_runner_heavy_output, log_online


### PR DESCRIPTION
Also introduced parametric testing there for both values of log_online

I think by default, we wouldn't even need to care about "online" logging, thus we can safely use communicate which might be more robust.  Thus I have now RF'ed to provide and test both implementations

TODO:  use log_online  for interactive (install, get) frontend commands.  Extend testing may be even more
