### PR TITLE
ENH: allow to specify location of the master collection via env variable

### DIFF
--- a/datalad/cmdline/helpers.py
+++ b/datalad/cmdline/helpers.py
@@ -228,8 +228,14 @@ from datalad.consts import DATALAD_COLLECTION_NAME
 
 dirs = AppDirs("datalad", "datalad.org")
 def get_datalad_master():
-    return CollectionRepo(opj(dirs.user_data_dir, DATALAD_COLLECTION_NAME),
-                          create=True)
+    """Return "master" collection on which all collection operations will be done
+    """
+    # Allow to have "master" collection be specified by environment variable
+    env_path = os.environ.get('DATALAD_COLLECTION_PATH', None)
+    return CollectionRepo(
+        env_path or opj(dirs.user_data_dir, DATALAD_COLLECTION_NAME),
+        create=True
+    )
 
 
 # Notes:


### PR DESCRIPTION
I think it would be the first step in that right direction ;-)

For current endeavors it would also simplify reproducibilty and troubleshooting of issues, e.g.

```
$> mkdir -p /tmp/test-col; cd /tmp/test-col; DATALAD_COLLECTION_PATH=/tmp/test-col datalad register-collection http://collections.datalad.org/pymvpa pymvpa-remote
# scary stuff

$> DATALAD_COLLECTION_PATH=$PWD datalad search-handle a    
haxby2001       http://data.pymvpa.org/datasets/haxby2001/.git
haxby2001       http://data.pymvpa.org/datasets/haxby2001/.git
mnist           ssh://datalad.org/srv/collections.datalad.org/www/pymvpa/mnist
mnist           ssh://datalad.org/srv/collections.datalad.org/www/pymvpa/mnist
tutorial_data   http://data.pymvpa.org/datasets/tutorial_data/.git
tutorial_data   http://data.pymvpa.org/datasets/tutorial_data/.git
2015-12-09 18:23:34,769 [ERROR  ] Unknown handle haxby2001 in branch master of repository /tmp/test-col. (ValueError) (main.py:206)
```

NB somehow search-collection issue didn't reproduce here... interesting
