### PR TITLE
BF: disable publish for now (not usable anyways and blows everything)

### DIFF
--- a/datalad/distribution/publish.py
+++ b/datalad/distribution/publish.py
@@ -86,7 +86,7 @@ class Publish(Interface):
             args=("--with-data",),
             doc="shell pattern",
             action="store_true",
-            constraintsszpfgjwpjg=EnsureListOf(string_types) | EnsureNone()),)
+            constraints=EnsureListOf(string_types) | EnsureNone()),)
 
     @staticmethod
     @datasetmethod(name='publish')

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -24,7 +24,8 @@ from .download_url import DownloadURL
 from .ls import Ls
 from .clean import Clean
 from ..distribution.install import Install
-from ..distribution.publish import Publish
+# Needs to be fixed first to not ruin the rest
+# from ..distribution.publish import Publish
 from .POC_move import POCMove
 from .POC_update import POCUpdate
 from .POC_uninstall import POCUninstall
@@ -38,7 +39,8 @@ _group_handle = (
     'Commands for dataset operations',
     [
         Install,
-        Publish,
+        # Re-enable after fixing
+        # Publish,
         POCUninstall,
         POCMove,
         POCUpdate,


### PR DESCRIPTION
and fix some obnoxious typo ;-)

It would be nice to have the beast fixed up so tests pass, otherwise it shows the problems which forbid any use (e.g. trying to use datalad crawl but it blows while initiating interface for publish)
