### PR TITLE
Primarily few scripts for tests

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -1121,6 +1121,7 @@ class Annexificator(object):
             for data_ in initiate_handle(*args, **kwargs)(data):
                 # Also "register" as a sub-handle if not yet registered
                 ds = Dataset(self.repo.path)
+                # TODO:  rename handle_  into dataset_
                 if data['handle_name'] not in ds.get_dataset_handles():
                     out = install(
                             dataset=ds,

--- a/datalad/crawler/pipelines/openfmri.py
+++ b/datalad/crawler/pipelines/openfmri.py
@@ -54,8 +54,11 @@ def pipeline(dataset, versioned_urls=True, topurl="https://openfmri.org/dataset/
         # all .txt and .json in root directory (only) go into git!
         options=["-c",
                  "annex.largefiles="
-                 "exclude=CHANGES* and exclude=README* and exclude=*.[mc] and exclude=dataset*.json"
-                 " and (exclude=*.txt or include=*/*.txt) "
+                 # ISSUES LICENSE Makefile
+                 "exclude=Makefile and exclude=LICENSE* and exclude=ISSUES*"
+                 " and exclude=CHANGES* and exclude=README*"
+                 " and exclude=*.[mc] and exclude=dataset*.json"
+                 " and (exclude=*.txt or include=*/*.txt)"
                  " and (exclude=*.json or include=*/*.json)"
                  " and (exclude=*.tsv or include=*/*.tsv)"
                  ])

--- a/datalad/distribution/tests/create_test_dataset.py
+++ b/datalad/distribution/tests/create_test_dataset.py
@@ -1,0 +1,168 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A Helper to initiate arbitrarily small/large test meta-dataset
+
+"""
+
+__docformat__ = 'restructuredtext'
+
+
+import random
+import logging
+import tempfile
+
+from datalad.utils import get_tempfile_kwargs
+import os
+from os.path import join as opj, abspath, relpath, pardir, isabs, isdir, \
+    exists, islink, sep
+from datalad.distribution.dataset import Dataset, datasetmethod, \
+    resolve_path, EnsureDataset
+from datalad.support.param import Parameter
+from datalad.support.constraints import EnsureStr, EnsureNone, EnsureInt, \
+    EnsureBool
+from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo, FileInGitError, \
+    FileNotInAnnexError
+from datalad.interface.base import Interface
+from datalad.cmd import CommandError
+from datalad.cmd import Runner
+from datalad.utils import expandpath, knows_annex, assure_dir, \
+    is_explicit_path, on_windows
+from datalad.interface.POC_helpers import get_git_dir
+
+lgr = logging.getLogger('datalad.distribution.tests')
+
+def _parse_spec(spec):
+    out = []   # will return a list of tuples (min, max) for each layer
+    for ilevel, level in enumerate(spec.split('/')):
+        minmax = level.split('-')
+        if len(minmax) == 1:  # only abs number specified
+            minmax = int(minmax[0])
+            min_, max_ = (minmax, minmax)
+        elif len(minmax) == 2:
+            min_, max_ = minmax
+            if not min_:  # might be omitted entirely
+                min_ = 0
+            if not max_:
+                raise ValueError("Specify max number at level %d. Full spec was: %s"
+                                 % (ilevel, spec))
+            min_ = int(min_)
+            max_ = int(max_)
+        else:
+            raise ValueError("Must have only min-max at level %d" % ilevel)
+        out.append((min_, max_))
+    return out
+
+
+def test_parse_spec():
+    from nose.tools import eq_
+    eq_(_parse_spec('0/3/-1'), [(0, 0), (3, 3), (0, 1)])
+    eq_(_parse_spec('4-10'), [(4, 10)])
+
+
+def _makeds(path, levels, ds=None):
+    # we apparently can't import api functionality within api
+    from datalad.api import install
+
+    # make it a git (or annex??) repository... ok - let's do randomly one or another ;)
+    RepoClass = GitRepo if random.randint(0, 1) else AnnexRepo
+    lgr.info("Generating repo of class %s under %s", RepoClass, path)
+    repo = RepoClass(path, create=True)
+    # let's create some dummy file and add it to the beast
+    fn = opj(path, "file%d.dat" % random.randint(1, 1000))
+    with open(fn, 'w') as f:
+        f.write(fn)
+    repo.git_add(fn)
+    repo.git_commit("Added %s" % fn)
+    if ds:
+        import pdb; pdb.set_trace()
+        rpath = './' + os.path.relpath(path, ds.path)
+        out = install(
+            dataset=ds,
+            path=rpath,
+            source=rpath,
+        )
+
+    if not levels:
+        return
+
+    # make a dataset for that one since we want to add sub datasets
+    ds_ = Dataset(path)
+    level, levels_ = levels[0], levels[1:]
+    nrepos = random.randint(*level)  # how many subds to generate
+    for irepo in range(nrepos):
+        # we would like to have up to 2 leading dirs
+        subds_path = opj(*(['d%i' % i for i in range(random.randint(0, 3))] + ['r%i' % irepo]))
+        subds_fpath = opj(path, subds_path)
+        yield subds_fpath
+        # and all under
+        for d in _makeds(subds_fpath, levels_, ds=ds_):
+            yield d
+
+class CreateTestDataset(Interface):
+    """Create test (meta-)dataset.
+    """
+
+    _params_ = dict(
+        path=Parameter(
+            args=("path",),
+            doc="path/name where to create (if specified, must not exist)",
+            constraints=EnsureStr() | EnsureNone()),
+        spec=Parameter(
+            args=("--spec",),
+            doc="""\
+            spec for hierarchy, defined as a min-max (min could be omitted to assume 0)
+            defining how many (random number from min to max) of sub-datasets to generate
+            at any given level of the hierarchy.  Each level separated from each other with /.
+            Example:  1-3/-2  would generate from 1 to 3 subdatasets at the top level, and
+            up to two within those at the 2nd level
+            """,
+            constraints=EnsureStr() | EnsureNone()),
+        seed=Parameter(
+            args=("--seed",),
+            doc="""seed for rng""",
+            constraints=EnsureInt() | EnsureNone()),
+
+    )
+
+    @staticmethod
+    def __call__(path=None, spec=None, seed=None):
+        if spec is None:
+            spec = "10/1-3/-2"  # 10 on top level, some random number from 1 to 3 at the 2nd, up to 2 on 3rd
+        levels = _parse_spec(spec)
+
+        if seed is not None:
+            # TODO: if to be used within a bigger project we shouldn't seed main RNG
+            random.seed(seed)
+        if path is None:
+            kw = get_tempfile_kwargs({}, prefix="ds")
+            path = tempfile.mktemp(mkdir=True, **kw)
+        else:
+            # so we don't override anything
+            assert not exists(path)
+            os.makedirs(path)
+
+        # now we should just make it happen and return list of all the datasets
+        return list(_makeds(path, levels))
+
+
+    @staticmethod
+    def result_renderer_cmdline(res):
+        from datalad.ui import ui
+        if res is None:
+            res = []
+        if not len(res):
+            ui.message("No repos were created... oops")
+            return
+        items= '\n'.join(map(str, res))
+        msg = "{n} installed {obj} available at\n{items}".format(
+            obj='items are' if len(res) > 1 else 'item is',
+            n=len(res),
+            items=items)
+        ui.message(msg)

--- a/datalad/interface/__init__.py
+++ b/datalad/interface/__init__.py
@@ -33,6 +33,9 @@ from ..distribution.create_publication_target_sshwebserver import \
 from ..distribution.install import Install
 from ..distribution.publish import Publish
 
+# very optional ones
+from ..distribution.tests.create_test_dataset import CreateTestDataset
+
 # all interfaces should be associated with (at least) one of the groups below
 _group_dataset = (
     'Commands for dataset operations',
@@ -61,4 +64,5 @@ _group_misc = (
         DownloadURL,
         Ls,
         Clean,
+        CreateTestDataset,
     ])

--- a/tools/git-web-submodules.sh
+++ b/tools/git-web-submodules.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Helper to replicate and demonstrate problem with git submodules being shared
+# as non-bare repos on the web
+
+set -eu
+
+topd=/tmp/gitxxmsxYFO #$(tempfile --prefix gitxxx)
+topd2=${topd}_
+topd3=${topd}__
+echo "I: directory $topd"
+rm -rf "$topd" "$topd2" "$topd3"
+
+gitcommit () {
+    git commit "$@"
+    # manually since we aren't pushing to it atm
+    git update-server-info
+}
+
+gitinit () {
+    git init
+    # make it servable from the web
+    mv .git/hooks/post-update.sample .git/hooks/post-update
+}
+
+gitaddfile() {
+    echo $1 > $1
+    git add $1
+    gitcommit -m "added $1"
+}
+
+startwebserver() {
+    python -m SimpleHTTPServer 8080 2>&1 | sed -e 's,^,  WEB: ,g' &
+    sleep 1  # to give it time to start
+}
+
+# Initiate a repo with a submodule with relative path
+mkdir $topd
+cd $topd
+mkdir -p $topd
+gitinit
+gitaddfile f1
+
+mkdir sub1
+cd sub1
+gitinit
+gitaddfile f2
+cd ..
+
+git submodule add ./sub1 sub1
+gitcommit -m 'Added sub1 submodule' -a
+
+# Expose under the webserver
+startwebserver
+
+# Try to clone and update submodule
+git clone http://localhost:8080/.git $topd2
+cd $topd2
+# and initialize submodule
+git submodule update --init || echo "E: FAILED!"
+
+# but we can still do it if we adjust the url for already inited submodule
+sed -i -e 's|/.git/sub1|/sub1/.git|g' .git/config
+git submodule update --init
+echo "I: SUCCESS and the content of file is ..."
+cd sub1
+cat f2
+# so we could serve later as well
+git update-server-info
+cd ..
+git update-server-info
+# kill the webserver
+kill %1
+sleep 1
+
+echo "I: now trying to serve the cloned repo which has a gitlink for sub1/.git"
+# Expose under the webserver
+startwebserver
+
+# Try to clone and update submodule
+git clone http://localhost:8080/.git $topd3
+cd $topd3
+# and initialize submodule
+git submodule update --init || echo "E: FAILED!"
+
+# but we can still do it if we adjust the url for already inited submodule
+sed -i -e 's|/.git/sub1|/sub1/.git|g' .git/config
+git submodule update --init || echo "E: Remains broken, I guess due to sub1/.git being a gitlink and git not following its pointer"
+#echo "I: SUCCESS and the content of file is ..."
+#cat sub1/f2
+
+kill %1
+


### PR DESCRIPTION
It should have worked but it doesn't due to something funky with how `install` behaves. Whenever I have provided full paths to both path and source just to get it registered as submodule (which I believe did nearly the same way before) if failed... with proper relative for both (as now) -- fails (since submodule needs relative path for source), if I add relative path only to source -- also fails but differently.  So @bpoldrack may be you would just figure it all out, otherwise script might be already working ;)  e.g. here is a sample invocation (and Ihave left pdb invocation so you could just dive in right away to figure it out)

```
> rm -rf /tmp/123; datalad --dbg create-test-dataset --seed 0 --spec 1-3 -l info /tmp/123
```
