### PR TITLE
RF: humble attempt to help

### DIFF
--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -697,7 +697,7 @@ class Annexificator(object):
 
         def switch_branch(data):
             """Switches to the branch %s""" % branch
-            # if self.repo.dirty()
+            # if self.repo.dirty
             list(self.finalize()(data))
             # statusdb is valid only within the same branch
             self._statusdb = None

--- a/datalad/crawler/nodes/annex.py
+++ b/datalad/crawler/nodes/annex.py
@@ -334,7 +334,7 @@ class Annexificator(object):
         self._providers = Providers.from_config_files()
         self.yield_non_updated = yield_non_updated
 
-        if (not allow_dirty) and self.repo.dirty():
+        if (not allow_dirty) and self.repo.dirty:
             raise RuntimeError("Repository %s is dirty.  Finalize your changes before running this pipeline" % path)
 
         self.statusdb = statusdb
@@ -724,7 +724,7 @@ class Annexificator(object):
                     # new detached branch
                     lgr.info("Checking out a new detached branch %s" % (branch))
                     self.repo.checkout(branch, options=["--orphan"])
-                    if self.repo.dirty():
+                    if self.repo.dirty:
                         self.repo.remove('.', r=True, f=True)  # TODO: might be insufficient if directories etc TEST/fix
                 else:
                     if parent not in existing_branches:
@@ -776,7 +776,7 @@ class Annexificator(object):
                 orig_branch = None
                 target_branch_ = self.repo.get_active_branch()
 
-            if self.repo.dirty():
+            if self.repo.dirty:
                 raise RuntimeError("Requested to merge another branch while current state is dirty")
 
             last_merged_checksum = self.repo.get_merge_base([target_branch_, branch])
@@ -849,7 +849,7 @@ class Annexificator(object):
             self._statusdb.save()
         # there is something to commit and backends was set but no .gitattributes yet
         path = self.repo.path
-        if self.repo.dirty() and not exists(opj(path, '.gitattributes')):
+        if self.repo.dirty and not exists(opj(path, '.gitattributes')):
             backends = self.repo.default_backends
             if backends:
                 # then record default backend into the .gitattributes
@@ -1299,7 +1299,7 @@ class Annexificator(object):
         def _finalize(data):
             self._precommit()
             stats = data.get('datalad_stats', None)
-            if self.repo.dirty():  # or self.tracker.dirty # for dry run
+            if self.repo.dirty:  # or self.tracker.dirty # for dry run
                 lgr.info("Repository found dirty -- adding and committing")
                 _call(self.repo.add, '.', options=self.options)  # so everything is committed
 

--- a/datalad/crawler/nodes/tests/test_annex.py
+++ b/datalad/crawler/nodes/tests/test_annex.py
@@ -204,13 +204,13 @@ def _test_add_archive_content_tar(direct, repo_path):
                  [{'datalad_stats': ActivityStats(add_annex=1, add_git=1, files=3, renamed=2),
                    'filename': '1.tar'}])
     if not direct:  # Notimplemented otherwise
-        assert_true(annex.repo.dirty())
+        assert_true(annex.repo.dirty)
     annex.repo.commit("added")
     ok_file_under_git(annex.repo.path, 'file.txt', annexed=False)
     ok_file_under_git(annex.repo.path, '1.dat', annexed=True)
     assert_false(lexists(opj(repo_path, '1.tar')))
     if not direct:  # Notimplemented otherwise
-        assert_false(annex.repo.dirty())
+        assert_false(annex.repo.dirty)
 
 
 def test_add_archive_content_tar():

--- a/datalad/crawler/nodes/tests/test_s3.py
+++ b/datalad/crawler/nodes/tests/test_s3.py
@@ -195,7 +195,7 @@ def test_crawl_s3_file_to_directory(path):
     with externals_use_cassette('test_crawl_s3_file_to_directory-pipeline1'):
         with swallow_logs() as cml:
             out = run_pipeline(pipeline)
-    assert(annex.repo.dirty())
+    assert(annex.repo.dirty)
     list(annex.finalize()(out[0]))
     # things are committed and thus stats are empty
     eq_(out, [{'datalad_stats': ActivityStats()}])

--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -350,7 +350,7 @@ def initiate_pipeline_config(template, template_func=None, template_kwargs=None,
     if commit:
         repo = GitRepo(path)
         repo.add(crawl_config_repo_path)
-        if repo.dirty():
+        if repo.dirty:
             repo.commit("Initialized crawling configuration to use template %s" % template,
                         _datalad_msg=True)
         else:

--- a/datalad/crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad/crawler/pipelines/tests/test_openfmri_collection.py
@@ -75,7 +75,7 @@ def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
     # Check that crawling configuration was created for every one of those
     for sub in subdatasets:
         repo = GitRepo(opj(outd, sub))
-        assert(not repo.dirty())
+        assert(not repo.dirty)
         assert(exists(opj(repo.path, CRAWLER_META_CONFIG_PATH)))
 
     # TODO: check that configuration for the crawler is up to the standard

--- a/datalad/distribution/tests/test_add.py
+++ b/datalad/distribution/tests/test_add.py
@@ -87,7 +87,7 @@ def test_add_files(path):
             result = ds.add(arg[0], to_git=arg[1], save=False)
         # TODO eq_(result, arg[0])
         # added, but not committed:
-        ok_(ds.repo.dirty())
+        ok_(ds.repo.dirty)
 
         # get sets for comparison:
         annexed = set(ds.repo.get_annexed_files())
@@ -115,14 +115,14 @@ def test_add_recursive(path):
     ds.create(force=True, save=False)
     subds = ds.create('dir', force=True)
     ds.save("Submodule added.")
-    ok_(subds.repo.dirty())
+    ok_(subds.repo.dirty)
 
     # no subds without recursive:
     ds.add('.', recursive=False)
-    ok_(subds.repo.dirty())
+    ok_(subds.repo.dirty)
     # nosubds with recursion limit too low:
     ds.add('.', recursive=True, recursion_limit=0)
-    ok_(subds.repo.dirty())
+    ok_(subds.repo.dirty)
 
     # add while also instructing annex to add in parallel 2 jobs (smoke testing
     # for that effect ATM)
@@ -158,7 +158,7 @@ def test_relpath_add(path):
         # and now add all
         add('..')
     # auto-save enabled
-    assert_false(ds.repo.dirty())
+    assert_false(ds.repo.dirty)
 
 
 @with_tree(tree={'file1.txt': 'whatever 1',
@@ -254,8 +254,8 @@ def test_add_source(path, url, ds_dir):
 def test_add_subdataset(path):
     subds = create(opj(path, 'dir'), force=True)
     ds = create(path, force=True)
-    ok_(subds.repo.dirty())
-    ok_(ds.repo.dirty())
+    ok_(subds.repo.dirty)
+    ok_(ds.repo.dirty)
     assert_not_in('dir', ds.get_subdatasets())
     # without a base dataset the next is interpreted as "add everything
     # in subds to subds"

--- a/datalad/distribution/tests/test_create.py
+++ b/datalad/distribution/tests/test_create.py
@@ -151,13 +151,13 @@ def test_create_subdataset_hierarchy_from_top(path):
     # we got a dataset ....
     ok_(ds.is_installed())
     # ... but it has untracked content
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
     subds = ds.create('sub', force=True)
     ok_(subds.is_installed())
-    ok_(subds.repo.dirty())
+    ok_(subds.repo.dirty)
     subsubds = subds.create('subsub', force=True)
     ok_(subsubds.is_installed())
-    ok_(subsubds.repo.dirty())
+    ok_(subsubds.repo.dirty)
     ds.save(recursive=True, all_updated=True)
     ok_clean_git(ds.path)
     ok_(ds.id != subds.id != subsubds.id)
@@ -211,7 +211,7 @@ def test_saving_prior(topdir):
     # so we create first top one
     ds1 = create(topdir, force=True)
     # and everything is ok, stuff is not added BUT ds1 will be considered dirty
-    ok_(ds1.repo.dirty())
+    ok_(ds1.repo.dirty)
     # And then we would like to initiate a sub1 subdataset
     ds2 = create('ds2', dataset=ds1, force=True)
     # But what will happen is file1.txt under ds2 would get committed first into

--- a/datalad/distribution/tests/test_install.py
+++ b/datalad/distribution/tests/test_install.py
@@ -756,7 +756,7 @@ def test_install_consistent_state(src, dest, dest2, dest3):
             eq_(ds.repo.get_active_branch(), "master")
             # all of them should be clean, so sub should be installed in a "version"
             # as pointed by the super
-            ok_(not ds.repo.dirty())
+            ok_(not ds.repo.dirty)
 
     dest_ds = install(dest, source=src)
     # now we progress sub1 by adding sub2

--- a/datalad/interface/add_archive_content.py
+++ b/datalad/interface/add_archive_content.py
@@ -226,7 +226,7 @@ class AddArchiveContent(Interface):
         archive_rpath = relpath(archive_path, annex_path)
 
         # TODO: somewhat too cruel -- may be an option or smth...
-        if not allow_dirty and annex.dirty():
+        if not allow_dirty and annex.dirty:
             # already saved me once ;)
             raise RuntimeError("You better commit all the changes and untracked files first")
 
@@ -477,7 +477,7 @@ class AddArchiveContent(Interface):
                 commit_stats = outside_stats if outside_stats else stats
                 annex.precommit()  # so batched ones close and files become annex symlinks etc
                 precommitted = True
-                if annex.dirty(untracked_files=False):
+                if annex.is_dirty(untracked_files=False):
                     annex.commit(
                         "Added content extracted from %s %s\n\n%s" %
                         (origin, archive, commit_stats.as_str(mode='full')),

--- a/datalad/interface/ls.py
+++ b/datalad/interface/ls.py
@@ -229,7 +229,7 @@ class GitModel(object):
 
     @property
     def clean(self):
-        return not self.repo.dirty()
+        return not self.repo.dirty
 
     @property
     def describe(self):

--- a/datalad/interface/tests/test_save.py
+++ b/datalad/interface/tests/test_save.py
@@ -40,7 +40,7 @@ def test_save(path):
         f.write("something")
 
     ds.repo.add("new_file.tst", git=True)
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
 
     # no all_changes any longer
     with assert_raises(DeprecatedError):
@@ -52,7 +52,7 @@ def test_save(path):
     with open(opj(path, "new_file.tst"), "w") as f:
         f.write("modify")
 
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
     ds.save("modified new_file.tst", all_updated=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
 
@@ -93,7 +93,7 @@ def test_save(path):
     ok_clean_git(subds.path, annex=isinstance(subds.repo, AnnexRepo))
     # Note/TODO: ok_clean_git is failing in direct mode, due to staged but
     # uncommited .datalad (probably caused within create)
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
     # ensure modified subds is committed
     ds.save(all_updated=True)
     ok_clean_git(path, annex=isinstance(ds.repo, AnnexRepo))
@@ -126,10 +126,10 @@ def test_recursive_save(path):
     subsubds.add(newfile_name, save=False)
 
     # but remains dirty because of the untracked file down below
-    assert ds.repo.dirty()
+    assert ds.repo.dirty
     # auto-add will save nothing deep down without recursive
     assert_status('notneeded', ds.save(all_updated=True))
-    assert ds.repo.dirty()
+    assert ds.repo.dirty
     # with recursive pick up the change in subsubds
     assert_result_values_equal(
         ds.save(all_updated=True, recursive=True, result_filter=is_ok_dataset),
@@ -167,16 +167,16 @@ def test_recursive_save(path):
     for old, new in zip(states, newstates):
         assert_not_equal(old, new)
     # now let's check saving "upwards"
-    assert not subds.repo.dirty()
+    assert not subds.repo.dirty
     create_tree(subds.path, {"testnew": 'smth', "testadded": "added"})
     subds.repo.add("testadded")
     indexed_files = subds.repo.get_indexed_files()
-    assert subds.repo.dirty()
-    assert ds.repo.dirty()
+    assert subds.repo.dirty
+    assert ds.repo.dirty
 
-    assert not subsubds.repo.dirty()
+    assert not subsubds.repo.dirty
     create_tree(subsubds.path, {"testnew2": 'smth'})
-    assert subsubds.repo.dirty()
+    assert subsubds.repo.dirty
     # and indexed files didn't change
     assert_equal(indexed_files, subds.repo.get_indexed_files())
     ok_clean_git(subds.repo, untracked=['testnew'],

--- a/datalad/interface/tests/test_utils.py
+++ b/datalad/interface/tests/test_utils.py
@@ -178,13 +178,13 @@ def test_save_hierarchy(path):
     # introduce a change at the lowest level
     ds_bbaa.repo.remove('file_bbaa')
     for d in (ds, ds_bb, ds_bba, ds_bbaa):
-        ok_(d.repo.dirty())
+        ok_(d.repo.dirty)
     ds_bb.save(files=ds_bbaa.path, super_datasets=True)
     # it has saved all changes in the subtrees spanned
     # by the given datasets, but nothing else
     for d in (ds_bb, ds_bba, ds_bbaa):
         ok_clean_git(d.path)
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
     # now with two modified repos
     d = Dataset(opj(ds.path, 'd'))
     da = Dataset(opj(d.path, 'da'))
@@ -195,7 +195,7 @@ def test_save_hierarchy(path):
     list(save_dataset_hierarchy((d.path, da.path, db.path)))
     for d in (d, da, db):
         ok_clean_git(d.path)
-    ok_(ds.repo.dirty())
+    ok_(ds.repo.dirty)
     # and now with files all over the place and saving
     # all the way to the root
     aa = Dataset(opj(ds.path, 'a', 'aa'))

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -99,9 +99,9 @@ def handle_dirty_dataset(ds, mode, msg=None):
     if mode == 'ignore':
         return
     elif mode == 'fail':
-        if not ds.repo or ds.repo.dirty(index=True,
-                                        untracked_files=True,
-                                        submodules=True):
+        if not ds.repo or ds.repo.is_dirty(index=True,
+                                           untracked_files=True,
+                                           submodules=True):
             raise RuntimeError('dataset {} has unsaved changes'.format(ds))
     elif mode == 'save-before':
         if not ds.is_installed():
@@ -148,9 +148,9 @@ def handle_dirty_datasets(dpaths,
             if not ds.repo:
                 continue
             ds.repo.precommit()
-            if ds.repo.dirty(index=True,
-                             untracked_files=True,
-                             submodules=True):
+            if ds.repo.is_dirty(index=True,
+                                untracked_files=True,
+                                submodules=True):
                 raise RuntimeError(
                     'dataset {} has unsaved changes'.format(ds))
     else:
@@ -386,7 +386,7 @@ def save_dataset(
         _datalad_msg = True
 
     # TODO: Remove dirty() altogether???
-    if files or ds.repo.dirty(
+    if files or ds.repo.is_dirty(
             index=True,
             untracked_files=False,
             submodules=True):

--- a/datalad/metadata/aggregate.py
+++ b/datalad/metadata/aggregate.py
@@ -173,7 +173,7 @@ def _within_metadata_store(ds, guess_native_type, metapath):
 
 def _save_helper(ds, save, modified_ds):
     old_state = ds.repo.get_hexsha()
-    if save and ds.repo.dirty(
+    if save and ds.repo.is_dirty(
             index=True,
             working_tree=False,
             submodules=True):

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -379,7 +379,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             elif GitRepo.is_valid_repo(opj(self.path, sm.path)):
                 sm_repo = GitRepo(opj(self.path, sm.path))
 
-                # TODO: Clarify issue: GitRepo.dirty() doesn't fit our parameters
+                # TODO: Clarify issue: GitRepo.is_dirty() doesn't fit our parameters
                 if sm_repo.is_dirty(index=deleted or modified or added or type_changed,
                                     working_tree=deleted or modified or added or type_changed,
                                     untracked_files=untracked,
@@ -507,8 +507,8 @@ class AnnexRepo(GitRepo, RepoInterface):
     @borrowdoc(GitRepo)
     def is_dirty(self, index=True, working_tree=False, untracked_files=True,
                  submodules=True, path=None):
-        # TODO: Add doc on how this differs from GitRepo.dirty()
-        # Parameter working_tree exists to meet the signature of GitRepo.dirty()
+        # TODO: Add doc on how this differs from GitRepo.is_dirty()
+        # Parameter working_tree exists to meet the signature of GitRepo.is_dirty()
 
         if working_tree:
             # Note: annex repos don't always have a git working tree and the

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -357,7 +357,7 @@ class AnnexRepo(GitRepo, RepoInterface):
             # First check for changes committed in the submodule, using
             # git submodule summary -- path,
             # since this can't be detected from within the submodule.
-            if self.submodules_is_modified(sm.name):
+            if self.is_submodule_modified(sm.name):
                 sm_dirty = True
 
             # check state of annex submodules, that might be in direct mode

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1692,8 +1692,8 @@ class GitRepo(RepoInterface):
         )
         # TODO: Return values?
 
-    def dirty(self, index=True, working_tree=True, untracked_files=True,
-              submodules=True, path=None):
+    def is_dirty(self, index=True, working_tree=True, untracked_files=True,
+                 submodules=True, path=None):
         """Returns true if the repo is considered to be dirty
 
         Parameters
@@ -1716,6 +1716,10 @@ class GitRepo(RepoInterface):
         return self.repo.is_dirty(index=index, working_tree=working_tree,
                                   untracked_files=untracked_files,
                                   submodules=submodules, path=path)
+
+    @property
+    def dirty(self):
+        return self.is_dirty()
 
     @property
     def untracked_files(self):

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -1741,7 +1741,7 @@ class GitRepo(RepoInterface):
             submodules = sorted(submodules, key=lambda x: x.path)
         return submodules
 
-    def submodules_is_modified(self, name, options=[]):
+    def is_submodule_modified(self, name, options=[]):
         """Whether a submodule has new commits
 
         Note: This is an adhoc method. It parses output of

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -128,7 +128,7 @@ def test_GitRepo_add(src, path):
     assert_in(filename, gr.get_indexed_files(),
               "%s not successfully added to %s" % (filename, path))
     # uncommitted:
-    ok_(gr.dirty())
+    ok_(gr.dirty)
 
     filename = "another.txt"
     with open(opj(path, filename), 'w') as f:
@@ -188,7 +188,7 @@ def test_GitRepo_commit(path):
     gr.add(filename)
     gr.commit("commit with options", options=to_options(dry_run=True))
     # wasn't actually committed:
-    ok_(gr.dirty())
+    ok_(gr.dirty)
 
     # commit with empty message:
     gr.commit()
@@ -676,30 +676,30 @@ def test_GitRepo_get_toppath(repo, tempdir, repo2):
 def test_GitRepo_dirty(path):
 
     repo = GitRepo(path, create=True)
-    ok_(not repo.dirty())
+    ok_(not repo.dirty)
 
     # untracked file
     with open(opj(path, 'file1.txt'), 'w') as f:
         f.write('whatever')
-    ok_(repo.dirty())
+    ok_(repo.dirty)
     # staged file
     repo.add('file1.txt')
-    ok_(repo.dirty())
+    ok_(repo.dirty)
     # clean again
     repo.commit("file1.txt added")
-    ok_(not repo.dirty())
+    ok_(not repo.dirty)
     # modify to be the same
     with open(opj(path, 'file1.txt'), 'w') as f:
         f.write('whatever')
-    ok_(not repo.dirty())
+    ok_(not repo.dirty)
     # modified file
     with open(opj(path, 'file1.txt'), 'w') as f:
         f.write('something else')
-    ok_(repo.dirty())
+    ok_(repo.dirty)
     # clean again
     repo.add('file1.txt')
     repo.commit("file1.txt modified")
-    ok_(not repo.dirty())
+    ok_(not repo.dirty)
 
     # TODO: submodules
 
@@ -796,7 +796,7 @@ def test_git_custom_calls(path, path2):
 
     # actually executed:
     assert_in("cc_test.dat", repo.get_indexed_files())
-    ok_(repo.dirty())
+    ok_(repo.dirty)
 
     # call using cmd_options:
     out, err = repo._gitpy_custom_call('commit',

--- a/datalad/tests/utils.py
+++ b/datalad/tests/utils.py
@@ -212,15 +212,15 @@ def ok_clean_git(path, annex=None, head_modified=[], index_modified=[],
             lgr.warning("head_modified and index_modified are not quite valid "
                         "concepts in direct mode! Looking for any change "
                         "(staged or not) instead.")
-            status = r.status(untracked=False, submodules=not ignore_submodules)
+            status = r.get_status(untracked=False, submodules=not ignore_submodules)
             modified = []
             for s in status:
                 modified.extend(status[s])
             eq_(sorted(head_modified + index_modified),
                 sorted(f for f in modified))
         else:
-            ok_(not r.dirty(untracked_files=not untracked,
-                            submodules=not ignore_submodules))
+            ok_(not r.is_dirty(untracked_files=not untracked,
+                               submodules=not ignore_submodules))
     else:
         repo = r.repo
 


### PR DESCRIPTION
1. commit 37dce395c8d507e67276a9cd1ee757038dd0a69e
    RF: dirty() -> is_dirty(), dirty -> is_dirty(), status() -> get_status()
    
    1. to stay consistent with other methods in the *Repo API.  Imperative names
       for methods and nouns for properties.  is_ is a common prefix for such methods
       with only few exceptions which we might like to address
    
    2. to minimize the diff (make it easier to review) for the PR#1450

compare:

```
$> git diff origin/rf-returnvalues...gh-bpoldrack/bf-direct-against-returnvalues --stat | tail -n 1
 21 files changed, 1090 insertions(+), 329 deletions(-)

$> git diff origin/rf-returnvalues... --stat | tail -n 1                                           
 11 files changed, 1034 insertions(+), 266 deletions(-)
```
so changes to half of the files in #1450 apparently had no functional changes really

2. commit 3c3245f683b3aabebe14ca666f5a7a2948b39e2f
    RF: submodules_is_modified -> is_submodule_modified
    
    1. to be inline with other methods which are other imperative or a property
    2. to make more sense/correspondence with reality (takes a single submodule)

Not sure if I broke or not anything, will submit PR also against main repo to see 
